### PR TITLE
Experimental LSP integration using JetBrains LSP API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -349,7 +349,7 @@ ij_kotlin_wrap_elvis_expressions = 1
 ij_kotlin_wrap_expression_body_functions = 1
 ij_kotlin_wrap_first_method_in_call_chain = false
 
-[{*.markdown, *.md}]
+[{*.markdown,*.md}]
 ij_markdown_force_one_space_after_blockquote_symbol = true
 ij_markdown_force_one_space_after_header_symbol = true
 ij_markdown_force_one_space_after_list_bullet = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Experimental integration with CUE LSP, based on JetBrains' LSP support.
+
 ### Changed
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,11 @@ val pluginVersion: String by project
 val platformVersion: String by project
 val pluginSinceBuild: String by project
 
+// Helper property to simplify checks, using a loop to avoid repetitive string checks
+val platformVersionBuild = (242..293).firstOrNull { build -> // check 2024.2 and 242. prefixes for build = 242
+    platformVersion.startsWith("$build.") || platformVersion.startsWith("${2000 + build / 10}.${build % 10}")
+} ?: throw GradleException("Unable to find platform build for $platformVersion")
+
 group = "dev.monogon.cuelang"
 version = pluginVersion
 
@@ -40,10 +45,15 @@ dependencies {
     intellijPlatform {
         pluginVerifier()
 
-        intellijIdeaCommunity(platformVersion)
+        intellijIdeaUltimate(platformVersion)
         testFramework(TestFrameworkType.Bundled)
 
         bundledPlugin("org.intellij.intelliLang")
+
+        // 2024.3 extracted the built-in JSON support into a plugin, we need it for our tests
+        if (platformVersionBuild >= 243) {
+            bundledPlugin("com.intellij.modules.json")
+        }
     }
 
     // workaround for https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1663

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginSinceBuild = 242
 platformVersion = 2024.2
 #platformVersion = 2024.3
 #platformVersion = 2025.1
-#platformVersion = 2025.2
+#platformVersion = 2025.2.1
 
 overrideTestData=false
 

--- a/plugin-description.md
+++ b/plugin-description.md
@@ -7,3 +7,5 @@ Features:
 - Brace matching
 - Formatting with `cue fmt`
 - Language injection
+- Integration with the LSP support of the latest CUE versions.
+  LSP support is currently only available with commercial or unified JetBrains IDEs 2025.2.1 or newer.

--- a/src/main/java/dev/monogon/cue/cli/CueCommandService.java
+++ b/src/main/java/dev/monogon/cue/cli/CueCommandService.java
@@ -1,6 +1,7 @@
 package dev.monogon.cue.cli;
 
 import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.application.ApplicationManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,12 +13,29 @@ import java.util.concurrent.TimeUnit;
  */
 public interface CueCommandService {
     /**
+     * Locates the cue command line tool.
+     * If the path was configured by the user, this path will be returned. As a fallback, the cue binary will be searched in the PATH.
+     * If found cue binary is not executable, then {@code false} is returned.
+     *
+     * @return Return {@code true} if the cue command line tool is available, either with a configured path or in the PATH.
+     */
+    boolean isCueAvailable();
+
+    /**
      * Calls "cue fmt", writes the given content on STDIN and returns STDOUT on success (exit code 0) or an error in other cased.
      *
      * @return The formatted content, if available.
      */
     @Nullable
     String format(@NotNull String content, long timeout, TimeUnit unit) throws ExecutionException;
+
+    /**
+     * Creates a command line to launch the cue language server.
+     *
+     * @return The command line, if available. {@code null} if the cue binary is not available.
+     */
+    @Nullable
+    GeneralCommandLine createLSPCommandLine();
 
     static @NotNull CueCommandService getInstance() {
         return ApplicationManager.getApplication().getService(CueCommandService.class);

--- a/src/main/java/dev/monogon/cue/cli/DefaultCueCommandService.java
+++ b/src/main/java/dev/monogon/cue/cli/DefaultCueCommandService.java
@@ -6,6 +6,7 @@ import com.intellij.execution.configurations.PathEnvironmentVariableUtil;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.util.text.StringUtil;
 import dev.monogon.cue.Messages;
 import dev.monogon.cue.settings.CueLocalSettingsService;
 import org.jetbrains.annotations.NotNull;
@@ -14,28 +15,25 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 public class DefaultCueCommandService implements CueCommandService {
     @Override
+    public boolean isCueAvailable() {
+        return findCueBinaryPath() != null;
+    }
+
+    @Override
     public @Nullable String format(@NotNull String content, long timeout, TimeUnit unit) throws ExecutionException {
-        String cuePath = CueLocalSettingsService.getSettings().getCueExecutablePath();
-        if (cuePath == null || cuePath.isEmpty()) {
-            var envPath = PathEnvironmentVariableUtil.findInPath("cue");
-            if (envPath == null || !envPath.canExecute()) {
-                throw new ExecutionException(Messages.get("formatter.exeNotFound"));
-            }
-            cuePath = envPath.getAbsolutePath();
-        }
-        else {
-            if (!Files.isExecutable(Paths.get(cuePath))) {
-                throw new ExecutionException(Messages.get("formatter.userPathNotFound"));
-            }
+        var cuePath = findCueBinaryPath();
+        if (cuePath == null) {
+            throw new ExecutionException(Messages.get("cue.binary.notFoundOrNotExecutable"));
         }
 
         try {
-            GeneralCommandLine cmd = new GeneralCommandLine(cuePath, "fmt", "-");
+            GeneralCommandLine cmd = new GeneralCommandLine(cuePath.toString(), "fmt", "-");
             cmd.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
             cmd.withCharset(StandardCharsets.UTF_8);
 
@@ -64,5 +62,34 @@ public class DefaultCueCommandService implements CueCommandService {
         catch (IOException e) {
             throw new ExecutionException(Messages.get("formatter.cueExecuteError"), e);
         }
+    }
+
+    @Override
+    public @Nullable GeneralCommandLine createLSPCommandLine() {
+        var cuePath = findCueBinaryPath();
+        if (cuePath == null) {
+            return null;
+        }
+
+        return new GeneralCommandLine(cuePath.toString())
+            .withParameters("lsp", "serve")
+            .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
+    }
+
+    private @Nullable Path findCueBinaryPath() {
+        Path cueBinaryPath = null;
+
+        var configuredPath = CueLocalSettingsService.getSettings().getCueExecutablePath();
+        if (StringUtil.isNotEmpty(configuredPath)) {
+            cueBinaryPath = Paths.get(configuredPath);
+        }
+        else {
+            var envPath = PathEnvironmentVariableUtil.findInPath("cue");
+            if (envPath != null) {
+                cueBinaryPath = envPath.toPath();
+            }
+        }
+
+        return cueBinaryPath != null && Files.isExecutable(cueBinaryPath) ? cueBinaryPath : null;
     }
 }

--- a/src/main/java/dev/monogon/cue/lang/navigation/CuePsiStructureViewFactory.java
+++ b/src/main/java/dev/monogon/cue/lang/navigation/CuePsiStructureViewFactory.java
@@ -3,7 +3,6 @@ package dev.monogon.cue.lang.navigation;
 import com.intellij.ide.structureView.StructureViewBuilder;
 import com.intellij.ide.structureView.StructureViewModel;
 import com.intellij.ide.structureView.TreeBasedStructureViewBuilder;
-import com.intellij.json.structureView.JsonStructureViewModel;
 import com.intellij.lang.PsiStructureViewFactory;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiFile;
@@ -15,7 +14,7 @@ public class CuePsiStructureViewFactory implements PsiStructureViewFactory {
 
     @Override
     public @Nullable StructureViewBuilder getStructureViewBuilder(@NotNull PsiFile psiFile) {
-        if (! (psiFile instanceof CueFile)) {
+        if (!(psiFile instanceof CueFile)) {
             return null;
         }
         return new TreeBasedStructureViewBuilder() {

--- a/src/main/java/dev/monogon/cue/lsp/CueJetBrainsLspSupport.java
+++ b/src/main/java/dev/monogon/cue/lsp/CueJetBrainsLspSupport.java
@@ -1,0 +1,10 @@
+package dev.monogon.cue.lsp;
+
+import dev.monogon.cue.settings.CueLspSupport;
+
+public final class CueJetBrainsLspSupport implements CueLspSupport {
+    @Override
+    public boolean isLspSupported() {
+        return true;
+    }
+}

--- a/src/main/java/dev/monogon/cue/lsp/CueLspSettingListener.java
+++ b/src/main/java/dev/monogon/cue/lsp/CueLspSettingListener.java
@@ -1,0 +1,25 @@
+package dev.monogon.cue.lsp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.platform.lsp.api.LspServerManager;
+import dev.monogon.cue.settings.CueSettingsListener;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("UnstableApiUsage")
+public class CueLspSettingListener implements CueSettingsListener {
+    private final @NotNull Project project;
+
+    public CueLspSettingListener(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void lspStateChanged(boolean isNowEnabled) {
+        if (isNowEnabled) {
+            LspServerManager.getInstance(project).startServersIfNeeded(CueServerSupportProvider.class);
+        }
+        else {
+            LspServerManager.getInstance(project).stopServers(CueServerSupportProvider.class);
+        }
+    }
+}

--- a/src/main/java/dev/monogon/cue/lsp/CueServerDescriptor.java
+++ b/src/main/java/dev/monogon/cue/lsp/CueServerDescriptor.java
@@ -1,0 +1,30 @@
+package dev.monogon.cue.lsp;
+
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor;
+import dev.monogon.cue.Messages;
+import dev.monogon.cue.cli.CueCommandService;
+import dev.monogon.cue.lang.CueFileType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+@SuppressWarnings("UnstableApiUsage")
+class CueServerDescriptor extends ProjectWideLspServerDescriptor {
+    public CueServerDescriptor(@NotNull Project project) {
+        super(project, Messages.get("cue.lsp.descriptor.name"));
+    }
+
+    @Override
+    public boolean isSupportedFile(@NotNull VirtualFile virtualFile) {
+        return CueFileType.INSTANCE.equals(virtualFile.getFileType());
+    }
+
+    @Override
+    public @NotNull GeneralCommandLine createCommandLine() {
+        // the availability of the cue binary was already checked in isSupportedFile()
+        return Objects.requireNonNull(CueCommandService.getInstance().createLSPCommandLine());
+    }
+}

--- a/src/main/java/dev/monogon/cue/lsp/CueServerSupportProvider.java
+++ b/src/main/java/dev/monogon/cue/lsp/CueServerSupportProvider.java
@@ -1,0 +1,32 @@
+package dev.monogon.cue.lsp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.lsp.api.LspServer;
+import com.intellij.platform.lsp.api.LspServerSupportProvider;
+import com.intellij.platform.lsp.api.lsWidget.LspServerWidgetItem;
+import dev.monogon.cue.Icons;
+import dev.monogon.cue.cli.CueCommandService;
+import dev.monogon.cue.lang.CueFileType;
+import dev.monogon.cue.settings.CueLocalSettingsService;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@SuppressWarnings("UnstableApiUsage")
+public class CueServerSupportProvider implements LspServerSupportProvider {
+    @Override
+    public void fileOpened(@NotNull Project project,
+                           @NotNull VirtualFile virtualFile,
+                           @NotNull LspServerSupportProvider.LspServerStarter serverStarter) {
+        if (CueFileType.INSTANCE.equals(virtualFile.getFileType()) &&
+            CueLocalSettingsService.getSettings().isLspEnabled() &&
+            CueCommandService.getInstance().isCueAvailable()) {
+            serverStarter.ensureServerStarted(new CueServerDescriptor(project));
+        }
+    }
+
+    @Override
+    public @Nullable LspServerWidgetItem createLspServerWidgetItem(@NotNull LspServer lspServer, @Nullable VirtualFile currentFile) {
+        return new LspServerWidgetItem(lspServer, currentFile, Icons.CueLogo, null);
+    }
+}

--- a/src/main/java/dev/monogon/cue/settings/CueLocalSettings.java
+++ b/src/main/java/dev/monogon/cue/settings/CueLocalSettings.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 public class CueLocalSettings {
     @Nullable
     private volatile String cueExecutablePath;
+    private boolean lspEnabled = true;
 
     @Nullable
     public String getCueExecutablePath() {
@@ -19,30 +20,31 @@ public class CueLocalSettings {
     }
 
     public void setCueExecutablePath(@Nullable String path) {
-        this.cueExecutablePath = path;
+        this.cueExecutablePath = StringUtil.nullize(path);
     }
 
-    @Override
-    public String toString() {
-        return "CueLocalSettings{" +
-               "cueExecutablePath='" + cueExecutablePath + '\'' +
-               '}';
+    public boolean isLspEnabled() {
+        return lspEnabled;
+    }
+
+    public void setLspEnabled(boolean lspEnabled) {
+        this.lspEnabled = lspEnabled;
+    }
+
+    public void applyFrom(@NotNull CueLocalSettings state) {
+        setCueExecutablePath(state.cueExecutablePath);
+        setLspEnabled(state.lspEnabled);
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        CueLocalSettings settings = (CueLocalSettings)o;
-        return Objects.equals(cueExecutablePath, settings.cueExecutablePath);
+        CueLocalSettings that = (CueLocalSettings)o;
+        return lspEnabled == that.lspEnabled && Objects.equals(cueExecutablePath, that.cueExecutablePath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(cueExecutablePath);
-    }
-
-    public void applyFrom(@NotNull CueLocalSettings state) {
-        this.cueExecutablePath = state.cueExecutablePath;
+        return Objects.hash(cueExecutablePath, lspEnabled);
     }
 }

--- a/src/main/java/dev/monogon/cue/settings/CueLspSupport.java
+++ b/src/main/java/dev/monogon/cue/settings/CueLspSupport.java
@@ -1,0 +1,23 @@
+package dev.monogon.cue.settings;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+
+/**
+ * Extension to let the main plugin know if LSP support is loaded.
+ */
+public interface CueLspSupport {
+    ExtensionPointName<CueLspSupport> EP_NAME = ExtensionPointName.create("dev.monogon.cuelang.lspSupportStatus");
+
+    /**
+     * @return {@code true} if the LSP support is available in the current IDE.
+     * Our LSP support is only loaded if the IDE provides LSP support.
+     */
+    boolean isLspSupported();
+
+    /**
+     * @return {@code true} if the LSP support is available in the current IDE, calls {@link #isLspSupported()}.
+     */
+    static boolean isLspSupportAvailable() {
+        return EP_NAME.findFirstSafe(CueLspSupport::isLspSupported) != null;
+    }
+}

--- a/src/main/java/dev/monogon/cue/settings/CueSettingsForm.form
+++ b/src/main/java/dev/monogon/cue/settings/CueSettingsForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="dev.monogon.cue.settings.CueSettingsForm">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -13,12 +13,12 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Path to &quot;cue&quot;:"/>
+          <text resource-bundle="messages/cuelang" key="applicationSettings.cuePath.label"/>
         </properties>
       </component>
       <vspacer id="8ee75">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="2be55" class="javax.swing.JTextField" binding="cuePathInput" custom-create="true">
@@ -28,6 +28,23 @@
           </grid>
         </constraints>
         <properties/>
+      </component>
+      <component id="46c7c" class="javax.swing.JCheckBox" binding="enableLSP">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="messages/cuelang" key="applicationSettings.lspSupport.label"/>
+        </properties>
+      </component>
+      <component id="ffba7" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="2" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="false"/>
+          <text resource-bundle="messages/cuelang" key="appliacationSettings.lspSupport.comment"/>
+        </properties>
       </component>
     </children>
   </grid>

--- a/src/main/java/dev/monogon/cue/settings/CueSettingsForm.java
+++ b/src/main/java/dev/monogon/cue/settings/CueSettingsForm.java
@@ -5,12 +5,14 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.components.JBTextField;
 import dev.monogon.cue.Messages;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
 public class CueSettingsForm {
     private JPanel mainPanel;
     private JTextField cuePathInput;
+    private JCheckBox enableLSP;
 
     @SuppressWarnings("DialogTitleCapitalization")
     private void createUIComponents() {
@@ -28,11 +30,15 @@ public class CueSettingsForm {
         return mainPanel;
     }
 
-    public void applyFrom(CueLocalSettings settings) {
+    public void applyFrom(@NotNull CueLocalSettings settings) {
         cuePathInput.setText(StringUtil.defaultIfEmpty(settings.getCueExecutablePath(), ""));
+        enableLSP.setSelected(settings.isLspEnabled());
+
+        enableLSP.setEnabled(CueLspSupport.isLspSupportAvailable());
     }
 
-    public void applyTo(CueLocalSettings settings) {
+    public void applyTo(@NotNull CueLocalSettings settings) {
         settings.setCueExecutablePath(cuePathInput.getText());
+        settings.setLspEnabled(enableLSP.isSelected());
     }
 }

--- a/src/main/java/dev/monogon/cue/settings/CueSettingsListener.java
+++ b/src/main/java/dev/monogon/cue/settings/CueSettingsListener.java
@@ -1,0 +1,14 @@
+package dev.monogon.cue.settings;
+
+import com.intellij.util.messages.Topic;
+
+public interface CueSettingsListener {
+    Topic<CueSettingsListener> TOPIC = Topic.create("cue.settings", CueSettingsListener.class);
+
+    /**
+     * This is invoked after the state of the CUE LSP configuration changed.
+     * It's called after changes to the {@link CueLocalSettings#isLspEnabled()} flag
+     * or to the path of the CUE executable {@link CueLocalSettings#getCueExecutablePath()}.
+     */
+    void lspStateChanged(boolean isNowEnabled);
+}

--- a/src/main/resources/META-INF/plugin-lsp.xml
+++ b/src/main/resources/META-INF/plugin-lsp.xml
@@ -1,0 +1,15 @@
+<idea-plugin>
+    <projectListeners>
+        <listener topic="dev.monogon.cue.settings.CueSettingsListener"
+                  class="dev.monogon.cue.lsp.CueLspSettingListener"/>
+    </projectListeners>
+
+    <extensions defaultExtensionNs="dev.monogon.cuelang">
+        <lspSupportStatus implementation="dev.monogon.cue.lsp.CueJetBrainsLspSupport"/>
+    </extensions>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <!--suppress PluginXmlValidity -->
+        <platform.lsp.serverSupportProvider implementation="dev.monogon.cue.lsp.CueServerSupportProvider"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,18 @@
     <!-- Product and plugin compatibility requirements -->
     <!-- https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
+    <!--
+    com.intellij.modules.lsp is a module added with 2025.2.1 to allow to use LSP without declaring a dependency on
+    paid IDEs via com.intellij.modules.ultimate.
+    LSP support will only be enabled with a unified product version 2025.2.1 or later.
+    The ultimate module requires a paid subscription, even in the unified product distributions.
+    See https://platform.jetbrains.com/t/2025-2-how-can-i-run-tests-in-plugin-which-depends-on-ultimate/2399/3.
+    -->
+    <depends optional="true" config-file="plugin-lsp.xml">com.intellij.modules.lsp</depends>
+
+    <extensionPoints>
+        <extensionPoint name="lspSupportStatus" dynamic="true" interface="dev.monogon.cue.settings.CueLspSupport"/>
+    </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">
         <lang.parserDefinition language="CUE" implementationClass="dev.monogon.cue.lang.CueParserDefinition"/>
@@ -32,7 +44,8 @@
         <lang.braceMatcher language="CUE" implementationClass="dev.monogon.cue.lang.editor.CueBraceMatcher"/>
         <lang.quoteHandler language="CUE" implementationClass="dev.monogon.cue.lang.editor.CueQuoteHandler"/>
         <lineIndentProvider implementation="dev.monogon.cue.lang.editor.formatter.CueLineIndentProvider"/>
-        <enterBetweenBracesDelegate language="CUE" implementationClass="dev.monogon.cue.lang.editor.formatter.CueEnterBetweenBracesHandler"/>
+        <enterBetweenBracesDelegate language="CUE"
+                                    implementationClass="dev.monogon.cue.lang.editor.formatter.CueEnterBetweenBracesHandler"/>
 
         <languageInjectionPerformer language="CUE"
                                     implementationClass="dev.monogon.cue.lang.injection.CueLanguageInjectionPerformer"/>

--- a/src/main/resources/messages/cuelang.properties
+++ b/src/main/resources/messages/cuelang.properties
@@ -35,12 +35,16 @@ folding.settings.imports=Imports
 folding.settings.importGroups=Import group (...)
 folding.settings.multilineComments=Multiline comments
 
-formatter.exeNotFound=The cue executable couldn't be found
 formatter.cueExecuteError=Error executing cue fmt
 formatter.executing=Executing cue fmt
-formatter.userPathNotFound=The configured path to cue could not be found.
 
 applicationSettings.displayName=CUE Language
+applicationSettings.cuePath.label=Path to "cue":
 applicationSettings.cuePath.dialogTitle=Choose Path to "cue"
 applicationSettings.cuePath.dialogLabel=Choose the path to the cue command line tool
 applicationSettings.cuePath.emptyText=By default, "cue" is searched in $PATH
+applicationSettings.lspSupport.label=Use CUE LSP support
+cue.lsp.descriptor.name=CUE
+
+cue.binary.notFoundOrNotExecutable=The CUE binary is unavailable or not executable.
+appliacationSettings.lspSupport.comment=LSP support is only available if the current IDE provides it.

--- a/src/test/java/dev/monogon/cue/settings/CueSettingsFormTest.java
+++ b/src/test/java/dev/monogon/cue/settings/CueSettingsFormTest.java
@@ -1,0 +1,35 @@
+package dev.monogon.cue.settings;
+
+import dev.monogon.cue.CueLightTest;
+import org.junit.Test;
+
+public class CueSettingsFormTest extends CueLightTest {
+    @Test
+    public void applySettings() {
+        var settings = new CueLocalSettings();
+        settings.setCueExecutablePath("/path/to/cue");
+        settings.setLspEnabled(false);
+
+        var form = new CueSettingsForm();
+        form.applyFrom(settings);
+
+        var newSettings = new CueLocalSettings();
+        form.applyTo(newSettings);
+        assertEquals(settings, newSettings);
+    }
+
+    @Test
+    public void nullableCuePath() {
+        var settings = new CueLocalSettings();
+
+        // a null path must be set back to the settings as a null path, not an empty path
+        var form = new CueSettingsForm();
+        form.applyFrom(settings);
+
+        var newSettings = new CueLocalSettings();
+        form.applyTo(newSettings);
+        assertNull(newSettings.getCueExecutablePath());
+
+        assertEquals("Settings with an empty path must match, empty string is invalid", settings, newSettings);
+    }
+}


### PR DESCRIPTION
This PR integrates with JetBrains' LSP integration. 

Because the IDEs did not offer a module until 2025.2.1+ to depend on LSP support, the LSP support will only be available with this version or later version. JetBrains is only shipping LSP support with unified or commercial products.
With 2025.3 unified product packaging will be the default.

2025.2.1 has been released already, so a typical user, which has a recent IDE, will get LSP support by default.

- Integration with the JetBrains LSP layer in package `dev.monogon.cue.lsp`
- A settings listener is added to stop/start the LSP server after changes to the "Enable CUE LSP" setting
- An extension was added to detect the IDE's support for LSP at runtime. An extension is a clean way to check the availability without hacks like or hardcoded module IDs.

If the installed version of `cue` does not support the `cue lsp serve`  command, then the JetBrains LSP integration displays an error. Because the recent versions of cue bundle at least basic support for LSP, we don't check the installed flavor of `cue` on our own and rely on the LSP layer.

Settings if the IDE supports LSP:
<img width="1650" height="421" alt="image" src="https://github.com/user-attachments/assets/2893a495-ffd1-41a8-8428-90f4797560d4" />

Settings if the IDE does not support LSP:
<img width="1440" height="302" alt="image" src="https://github.com/user-attachments/assets/090b927a-2121-4c55-9e86-b9aa68efcbdf" />
